### PR TITLE
Fix issue in jquery 1.9 and later

### DIFF
--- a/js/jquery.bsmselect.js
+++ b/js/jquery.bsmselect.js
@@ -86,7 +86,7 @@
      * Check to make sure it's not an IE screwup, and add it to the list
      */
     selectChangeEvent: function() {
-      if ($.browser.msie && $.browser.version < 7 && !this.ieClick) { return; }
+      if ($.browser && $.browser.msie && $.browser.version < 7 && !this.ieClick) { return; }
       var bsmOpt = $('option:selected:eq(0)', this.$select);
       if (bsmOpt.data('orig-option')) {
         this.addListItem(bsmOpt);
@@ -115,7 +115,7 @@
         this.buildSelect();
         // opera has an issue where it needs a force redraw, otherwise
         // the items won't appear until something else forces a redraw
-        if ($.browser.opera) { this.$list.hide().show(); }
+        if ($.browser && $.browser.opera) { this.$list.hide().show(); }
       }
     },
 
@@ -198,7 +198,7 @@
         .removeAttr('selected')
         .attr('disabled', 'disabled')
         .toggle(!this.options.hideWhenAdded);
-      if ($.browser.msie && $.browser.version < 8) { this.$select.hide().show(); } // this forces IE to update display
+      if ($.browser && $.browser.msie && $.browser.version < 8) { this.$select.hide().show(); } // this forces IE to update display
     },
 
     /**
@@ -210,7 +210,7 @@
       $bsmOpt.removeClass(this.options.optionDisabledClass)
         .removeAttr('disabled')
         .toggle(!this.options.hideWhenAdded);
-      if ($.browser.msie && $.browser.version < 8) { this.$select.hide().show(); } // this forces IE to update display
+      if ($.browser && $.browser.msie && $.browser.version < 8) { this.$select.hide().show(); } // this forces IE to update display
     },
 
     /**


### PR DESCRIPTION
Starting with jquery 1.9 $.browser has been removed.  There are jquery addons that can get it back but my change is to test for existance of $browser before accessing any property in it.
