### PR TITLE
Update triggerOriginalChange function

### DIFF
--- a/js/jquery.bsmselect.js
+++ b/js/jquery.bsmselect.js
@@ -297,6 +297,7 @@
         option: $origOpt,
         value: $origOpt.val(),
         item: $origOpt.data('bsm-option').data('item'),
+        label: $origOpt.parents('optgroup').attr('label'), //ADDED to easely get data.label in optgroup selections
         type: type
       }]);
       return event.isDefaultPrevented();


### PR DESCRIPTION
Please, add
label: $origOpt.parents('optgroup').attr('label'), 
in order to easely get data.label in optgroup selections.
