### PR TITLE
added functionality to allow the user to move the location of the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ The newly created select default option is the original select title attribute:
   * Class for the label text that appears in list items.
   * Default: 'bsmListItemLabel'
 
+* listPlacementClass:
+
+  * Class for the label location (allows you to move the location of the list and maintain functionality). If false, default location is below the selecter.
+  * Default: false
+
 * removeClass:
 
   * Class given to the remove link in each list item.
@@ -188,6 +193,7 @@ The newly created select default option is the original select title attribute:
   * [Marc Busqué](https://github.com/laMarciana) has contributed to fix
     [issue #21](https://github.com/vicb/bsmSelect/issues/21) and with minimal CSS
   * [DrewBe121212](https://github.com/DrewBe121212) has fixed issues 28 et 29.
+  * [djekl](https://github.com/djekl) submitted PR to allow the ability to move the list.
 
 ## History ##
 

--- a/js/jquery.bsmselect.js
+++ b/js/jquery.bsmselect.js
@@ -66,7 +66,13 @@
       this.$original.change($.proxy(this.originalChangeEvent, this)).wrap(this.$container).before(this.$select);
 
       // if the list isn't already in the document, add it (it might be inserted by a custom callback)
-      if (!this.$list.parent().length) { this.$original.before(this.$list); }
+      if (!this.$list.parent().length) {
+        if (o.listPlacementClass !== false) {
+          $('.' + o.listPlacementClass).append(this.$list);
+        } else {
+          this.$original.before(this.$list);
+        }
+      }
 
       if (this.$original.attr('id')) {
         $("label[for='" + this.$original.attr('id') + "']").attr('for', this.$select.attr('id'));
@@ -380,6 +386,7 @@
     listClass: 'bsmList',                       // Class for the list ($list)
     listItemClass: 'bsmListItem',               // Class for the <li> list items
     listItemLabelClass: 'bsmListItemLabel',     // Class for the label text that appears in list items
+    listPlacementClass: false,                       // Class for the location of the list
     removeClass: 'bsmListItemRemove',           // Class given to the 'remove' link
     highlightClass: 'bsmHighlight'              // Class given to the highlight <span>
   };


### PR DESCRIPTION
Recently when working with this, the design called for the list to be in a different location than the form itself.

The functionality added allows the user to move the list to a new location within the dom.

Please see this for an example
![http://cl.ly/image/1w0t1W2m0i0E](http://f.cl.ly/items/3s06090e1A3J3I3a3J2G/Image%202014-08-13%20at%2012.16.39%20pm.png)

markup is as simple as;

``` javascript
$(".selectWeWantToUse").bsmSelect({
    title: "Add fields...",
    removeLabel: '<strong>&times;</strong>',
    listPlacementClass: 'newBsmListLocation'
});
```

This is the HTML of the new location (list is placed within this div)

``` html
<div class="newBsmListLocation" style="padding: 20px;"></div>
```
