### PR TITLE
Remove name from select container.

### DIFF
--- a/js/jquery.bsmselect.js
+++ b/js/jquery.bsmselect.js
@@ -47,7 +47,6 @@
 
       this.$select = $('<select>', {
         'class': o.selectClass,
-        name: o.selectClass + this.uid,
         id: o.selectClass + this.uid,
         change: $.proxy(this.selectChangeEvent, this),
         click: $.proxy(this.selectClickEvent, this)


### PR DESCRIPTION
The generated select container has a name which adds a bunch of

`?bsmSelectbsmContainer0=`

etc. to the query string when it's submitted.
